### PR TITLE
feat: directory dependencies are specified via the link:<path>

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import {PackageJson} from '@pnpm/types'
 import fs = require('graceful-fs')
-import normalize = require('normalize-path')
 import path = require('path')
 import readPackageJsonCB = require('read-package-json')
 import ssri = require('ssri')
@@ -28,27 +27,24 @@ export default async function resolveLocal (
   const spec = parsePref(wantedDependency.pref, opts.prefix)
   if (!spec) return null
 
-  const dependencyPath = normalize(path.relative(opts.prefix, spec.fetchSpec))
-  const id = `file:${dependencyPath}`
-
   if (spec.type === 'file') {
     return {
-      id,
+      id: spec.id,
       normalizedPref: spec.normalizedPref,
       resolution: {
         integrity: await getFileIntegrity(spec.fetchSpec),
-        tarball: id,
+        tarball: spec.id,
       },
     }
   }
 
   const localPkg = await readPackageJson(path.join(spec.fetchSpec, 'package.json'))
   return {
-    id,
+    id: spec.id,
     normalizedPref: spec.normalizedPref,
     package: localPkg,
     resolution: {
-      directory: dependencyPath,
+      directory: spec.dependencyPath,
       type: 'directory',
     },
   }

--- a/src/parsePref.ts
+++ b/src/parsePref.ts
@@ -1,3 +1,4 @@
+import normalize = require('normalize-path')
 import osenv = require('osenv')
 import path = require('path')
 
@@ -8,7 +9,9 @@ const isFilename = /[.](?:tgz|tar.gz|tar)$/i
 const isAbsolutePath = /^[/]|^[A-Za-z]:/
 
 export interface LocalPackageSpec {
+  dependencyPath: string,
   fetchSpec: string,
+  id: string,
   type: 'directory' | 'file',
   normalizedPref: string,
 }
@@ -17,43 +20,62 @@ export default function parsePref (
   pref: string,
   where: string,
 ): LocalPackageSpec | null {
+  if (pref.startsWith('link:')) {
+    return fromLocal(pref, where, 'directory')
+  }
   if (pref.endsWith('.tgz')
     || pref.endsWith('.tar.gz')
     || pref.endsWith('.tar')
     || pref.includes(path.sep)
     || pref.startsWith('file:')
     || isFilespec.test(pref)) {
-      return fromFile(pref, where)
+      const type = isFilename.test(pref) ? 'file' : 'directory'
+      return fromLocal(pref, where, type)
     }
+  if (pref.startsWith('path:')) {
+    const err = new Error('Local dependencies via `path:` prefix are not supported. ' +
+      'Use the `link:` prefix for folder dependencies and `file:` for local tarballs')
+    // tslint:disable:no-string-literal
+    err['code'] = 'INVALID_PREF'
+    err['pref'] = pref
+    // tslint:enable:no-string-literal
+    throw err
+  }
   return null
 }
 
-function fromFile (pref: string, where: string): LocalPackageSpec {
+function fromLocal (pref: string, where: string, type: 'file' | 'directory'): LocalPackageSpec {
   if (!where) where = process.cwd()
-  const type = isFilename.test(pref) ? 'file' : 'directory'
 
   const spec = pref.replace(/\\/g, '/')
-    .replace(/^file:[/]*([A-Za-z]:)/, '$1') // drive name paths on windows
-    .replace(/^file:(?:[/]*([~./]))?/, '$1')
+    .replace(/^(file|link):[/]*([A-Za-z]:)/, '$2') // drive name paths on windows
+    .replace(/^(file|link):(?:[/]*([~./]))?/, '$2')
+
+  // TODO: always use link: for directory dependencies
+  const prefPrefix = pref.startsWith('link:') ? 'link:' : 'file:'
+  let fetchSpec!: string
+  let normalizedPref!: string
   if (/^~[/]/.test(spec)) {
     // this is needed for windows and for file:~/foo/bar
-    return {
-      fetchSpec: resolvePath(osenv.home(), spec.slice(2)),
-      normalizedPref: `file:${spec}`,
-      type,
+    fetchSpec = resolvePath(osenv.home(), spec.slice(2))
+    normalizedPref = `${prefPrefix}${spec}`
+  } else {
+    fetchSpec = resolvePath(where, spec)
+    if (isAbsolute(spec)) {
+      normalizedPref = `${prefPrefix}${spec}`
+    } else {
+      normalizedPref = `${prefPrefix}${path.relative(where, fetchSpec)}`
     }
   }
-  const fetchSpec = resolvePath(where, spec)
-  if (isAbsolute(spec)) {
-    return {
-      fetchSpec,
-      normalizedPref: `file:${spec}`,
-      type,
-    }
-  }
+
+  const dependencyPath = normalize(path.relative(where, fetchSpec))
+  const id = `${prefPrefix}${dependencyPath}`
+
   return {
+    dependencyPath,
     fetchSpec,
-    normalizedPref: `file:${path.relative(where, fetchSpec)}`,
+    id,
+    normalizedPref,
     type,
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,26 @@ test('resolve directoty', async t => {
   t.end()
 })
 
+test('resolve directoty via file: prefix', async t => {
+  const resolveResult = await resolveFromLocal({pref: 'file:..'}, {prefix: __dirname})
+  t.equal(resolveResult!.id, 'file:..')
+  t.equal(resolveResult!.normalizedPref, 'file:..')
+  t.equal(resolveResult!['package'].name, '@pnpm/local-resolver')
+  t.equal(resolveResult!.resolution!['directory'], '..')
+  t.equal(resolveResult!.resolution!['type'], 'directory')
+  t.end()
+})
+
+test('resolve directoty via link: prefix', async t => {
+  const resolveResult = await resolveFromLocal({pref: 'link:..'}, {prefix: __dirname})
+  t.equal(resolveResult!.id, 'link:..')
+  t.equal(resolveResult!.normalizedPref, 'link:..')
+  t.equal(resolveResult!['package'].name, '@pnpm/local-resolver')
+  t.equal(resolveResult!.resolution!['directory'], '..')
+  t.equal(resolveResult!.resolution!['type'], 'directory')
+  t.end()
+})
+
 test('resolve file', async t => {
   const wantedDependency = {pref: './pnpm-local-resolver-0.1.1.tgz'}
   const resolveResult = await resolveFromLocal(wantedDependency, {prefix: __dirname})
@@ -25,4 +45,43 @@ test('resolve file', async t => {
   })
 
   t.end()
+})
+
+test('resolve file with file: prefixed', async t => {
+  const wantedDependency = {pref: 'file:./pnpm-local-resolver-0.1.1.tgz'}
+  const resolveResult = await resolveFromLocal(wantedDependency, {prefix: __dirname})
+
+  t.deepEqual(resolveResult, {
+    id: 'file:pnpm-local-resolver-0.1.1.tgz',
+    normalizedPref: 'file:pnpm-local-resolver-0.1.1.tgz',
+    resolution: {
+      integrity: 'sha512-UHd2zKRT/w70KKzFlj4qcT81A1Q0H7NM9uKxLzIZ/VZqJXzt5Hnnp2PYPb5Ezq/hAamoYKIn5g7fuv69kP258w==',
+      tarball: 'file:pnpm-local-resolver-0.1.1.tgz',
+    },
+  })
+
+  t.end()
+})
+
+test("fail when resolving tarball with link: prefix", async t => {
+  try {
+    const wantedDependency = {pref: 'link:./pnpm-local-resolver-0.1.1.tgz'}
+    const resolveResult = await resolveFromLocal(wantedDependency, {prefix: __dirname})
+    t.fail()
+  } catch (err) {
+    t.ok(err)
+    t.end()
+  }
+})
+
+test('throw error on path: prefixed local deps', async t => {
+  try {
+    await resolveFromLocal({pref: 'path:..'}, {prefix: __dirname})
+    t.fail()
+  } catch (err) {
+    t.ok(err)
+    t.equal(err.code, 'INVALID_PREF')
+    t.equal(err.pref, 'path:..')
+    t.end()
+  }
 })


### PR DESCRIPTION
BREAKING CHANGE:

throw an error if pref starts with `path:`

ref pnpm/pnpm#1061